### PR TITLE
xiaomi: fingerprint: Add blank callbacks for udfps

### DIFF
--- a/hidl/biometrics/fingerprint/BiometricsFingerprint.cpp
+++ b/hidl/biometrics/fingerprint/BiometricsFingerprint.cpp
@@ -418,6 +418,14 @@ void BiometricsFingerprint::notify(const fingerprint_msg_t* msg) {
     }
 }
 
+Return<void> BiometricsFingerprint::onShowUdfpsOverlay() {
+    return Void();
+}
+
+Return<void> BiometricsFingerprint::onHideUdfpsOverlay() {
+    return Void();
+}
+
 }  // namespace implementation
 }  // namespace V2_3
 }  // namespace fingerprint

--- a/hidl/biometrics/fingerprint/BiometricsFingerprint.h
+++ b/hidl/biometrics/fingerprint/BiometricsFingerprint.h
@@ -56,6 +56,8 @@ struct BiometricsFingerprint : public IBiometricsFingerprint {
     Return<RequestStatus> remove(uint32_t gid, uint32_t fid) override;
     Return<RequestStatus> setActiveGroup(uint32_t gid, const hidl_string& storePath) override;
     Return<RequestStatus> authenticate(uint64_t operationId, uint32_t gid) override;
+    Return<void> onShowUdfpsOverlay() override;
+    Return<void> onHideUdfpsOverlay() override;
 
     // Methods from ::android::hardware::biometrics::fingerprint::V2_3::IBiometricsFingerprint
     // follow.


### PR DESCRIPTION
Without this, build will throw error below:

device/xiaomi/raphael/fingerprint/BiometricsFingerprint.cpp:209:25: error: allocating an object of abstract class type 'android::hardware::biometrics::fingerprint::V2_3::implementation::BiometricsFingerprint'
        sInstance = new BiometricsFingerprint();
                        ^
out/soong/.intermediates/hardware/interfaces/biometrics/fingerprint/2.3/android.hardware.biometrics.fingerprint@2.3_genc++_headers/gen/android/hardware/biometrics/fingerprint/2.3/IBiometricsFingerprint.h:214:47: note: unimplemented pure virtual method 'onShowUdfpsOverlay' in 'BiometricsFingerprint'
    virtual ::android::hardware::Return<void> onShowUdfpsOverlay() = 0;
                                              ^
out/soong/.intermediates/hardware/interfaces/biometrics/fingerprint/2.3/android.hardware.biometrics.fingerprint@2.3_genc++_headers/gen/android/hardware/biometrics/fingerprint/2.3/IBiometricsFingerprint.h:219:47: note: unimplemented pure virtual method 'onHideUdfpsOverlay' in 'BiometricsFingerprint'
    virtual ::android::hardware::Return<void> onHideUdfpsOverlay() = 0;
                                              ^
since we don't use it, for now let's just satisfy it with blank callbacks.

Signed-off-by: Hưng Phan <phandinhhungvp2001@gmail.com>
Signed-off-by: SKORPION29 <sayansarkar29.slg@gmail.com>